### PR TITLE
Update JAXbind to silence deprecation warnings 

### DIFF
--- a/jaxbind/jaxbind.py
+++ b/jaxbind/jaxbind.py
@@ -11,6 +11,7 @@ from typing import Union
 import jax
 import jaxlib.mlir.dialects.stablehlo as hlo
 import jaxlib.mlir.ir as ir
+import jax.extend as jex
 import numpy as np
 from jax.interpreters import ad, batching, mlir
 from jax.interpreters.mlir import ir_constant as irc
@@ -386,7 +387,7 @@ def _batch(args, in_axes, *, _func: FunctionType, **kwargs):
 
 
 # actually register the above functions in JAX
-_prim = jax.core.Primitive("jaxbind_prim")
+_prim = jex.core.Primitive("jaxbind_prim")
 _prim.multiple_results = True
 _prim.def_impl(partial(jax.interpreters.xla.apply_primitive, _prim))
 _prim.def_abstract_eval(_exec_abstract)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
+  "packaging",
   "numpy >= 1.17.0",
   "jax >= 0.4",
   "jaxlib",


### PR DESCRIPTION
Custom primitives should now be created via the `jax.extend` module. I updated the code accordingly.

Furthermore, the C++ extension should be registered via `jax.ffi.register_ffi_target` instead of `jax.lib.xla_client.register_custom_call_target`.

As both changes require quite recent JAX versions I first check the installed JAX version before using the new interfaces.