### PR TITLE
Update cibuildwheel for new Python versions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - uses: pypa/cibuildwheel@v2.23.2
+      - uses: pypa/cibuildwheel@v3.3.1
         env:
           CIBW_ARCHS: auto64
           CIBW_BUILD_FRONTEND: build[uv]

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -24,10 +24,10 @@ jobs:
         env:
           CIBW_ARCHS: auto64
           CIBW_BUILD_FRONTEND: build[uv]
-          CIBW_SKIP: cp36-* cp37-* cp38-* pp* *-musllinux*
+          CIBW_SKIP: cp36-* cp37-* cp38-* pp* *-musllinux* cp314t-win*
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: python -m pytest -x {project}/test
-          CIBW_TEST_SKIP: cp36-* cp37-* cp38-* cp39-* cp310-* cp311-*
+          CIBW_TEST_SKIP: cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_MANYLINUX_I686_IMAGE: manylinux_2_28
           CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux_2_28

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: C++",
   "Programming Language :: Python",
 ]
-version = "1.3.0"
+version = "1.3.1"
 
 [project.urls]
 "Source Code" = "https://github.com/NIFTy-PPL/JAXbind"


### PR DESCRIPTION
This updates cibuildwheels to also build wheels for  Python 3.14 and 3.14t. As JAX does not support Python 3.14t on Windows, I skip building the 3.14t wheel for Windows.

Once we have merged this, I can tag this version and upload the wheels to PyPi.

@mreineck or @Edenhofer let me know in case you spot anything missing.